### PR TITLE
Replace "LR35902" with "SM83"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Gameboy CPU (Sharp LR35902) Tests
+# GameBoy CPU (SM83) Tests
 
-Test data for developers of Gameboy emulators. These files are designed for unit testing the CPU of the Gameboy (Sharp LR35902) in isolation and don't expect any other hardware components to be implemented.
+Test data for developers of Gameboy emulators. These files are designed for unit testing the CPU of the Gameboy (SM83) in isolation and don't expect any other hardware components to be implemented.
 
 * `alu_tests` **(Removed since [c7b4e6a](https://github.com/adtennant/sm83-test-data/commit/c7b4e6a5ee935d0c02dbc655a52b560ac42de392))** - Contains full test data for the 8-bit ALU operations of the Gameboy CPU.
 * `v1` **(Deprecated since [c7b4e6a](https://github.com/adtennant/sm83-test-data/commit/c7b4e6a5ee935d0c02dbc655a52b560ac42de392))** - Contains randomly generated test data for all Gameboy CPU instructions.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# GameBoy CPU (SM83) Tests
+# Game Boy CPU (SM83) Tests
 
-Test data for developers of Gameboy emulators. These files are designed for unit testing the CPU of the Gameboy (SM83) in isolation and don't expect any other hardware components to be implemented.
+Test data for developers of Game Boy emulators. These files are designed for unit testing the CPU of the Game Boy (SM83) in isolation and don't expect any other hardware components to be implemented.
 
-* `alu_tests` **(Removed since [c7b4e6a](https://github.com/adtennant/sm83-test-data/commit/c7b4e6a5ee935d0c02dbc655a52b560ac42de392))** - Contains full test data for the 8-bit ALU operations of the Gameboy CPU.
-* `v1` **(Deprecated since [c7b4e6a](https://github.com/adtennant/sm83-test-data/commit/c7b4e6a5ee935d0c02dbc655a52b560ac42de392))** - Contains randomly generated test data for all Gameboy CPU instructions.
-* `v2` - Updated randomly generated test data for all Gameboy CPU instructions in the same format as https://github.com/TomHarte/ProcessorTests.
+* `alu_tests` **(Removed since [c7b4e6a](https://github.com/adtennant/sm83-test-data/commit/c7b4e6a5ee935d0c02dbc655a52b560ac42de392))** - Contains full test data for the 8-bit ALU operations of the Game Boy CPU.
+* `v1` **(Deprecated since [c7b4e6a](https://github.com/adtennant/sm83-test-data/commit/c7b4e6a5ee935d0c02dbc655a52b560ac42de392))** - Contains randomly generated test data for all Game Boy CPU instructions.
+* `v2` - Updated randomly generated test data for all Game Boy CPU instructions in the same format as https://github.com/TomHarte/ProcessorTests.
 
 The main differences between `v2` and `v1` are:
 * The test format now correctly matches https://github.com/TomHarte/ProcessorTests.


### PR DESCRIPTION
"LR35902" as the name of the Game Boy's CPU is a misnomer, LR35902 is the name of the GB's SoC containing the SM83 CPU core along with components like the PPU, APU, etc. Thus referring to the GB's CPU as "SM83" is more correct